### PR TITLE
Add compatibility with Django 1.4.

### DIFF
--- a/django_messages/views.py
+++ b/django_messages/views.py
@@ -2,6 +2,7 @@ import datetime
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext
+from django.contrib import messages
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.utils.translation import ugettext as _
@@ -74,8 +75,7 @@ def compose(request, recipient=None, form_class=ComposeForm,
         form = form_class(request.POST, recipient_filter=recipient_filter)
         if form.is_valid():
             form.save(sender=request.user)
-            request.user.message_set.create(
-                message=_(u"Message successfully sent."))
+            messages.info(request, _(u"Message successfully sent."))
             if success_url is None:
                 success_url = reverse('messages_inbox')
             if request.GET.has_key('next'):
@@ -111,8 +111,7 @@ def reply(request, message_id, form_class=ComposeForm,
         form = form_class(request.POST, recipient_filter=recipient_filter)
         if form.is_valid():
             form.save(sender=request.user, parent_msg=parent)
-            request.user.message_set.create(
-                message=_(u"Message successfully sent."))
+            messages.info(request, _(u"Message successfully sent."))
             if success_url is None:
                 success_url = reverse('messages_inbox')
             return HttpResponseRedirect(success_url)
@@ -155,7 +154,7 @@ def delete(request, message_id, success_url=None):
         deleted = True
     if deleted:
         message.save()
-        user.message_set.create(message=_(u"Message successfully deleted."))
+        messages.info(request, _(u"Message successfully deleted."))
         if notification:
             notification.send([user], "messages_deleted", {'message': message,})
         return HttpResponseRedirect(success_url)
@@ -182,7 +181,7 @@ def undelete(request, message_id, success_url=None):
         undeleted = True
     if undeleted:
         message.save()
-        user.message_set.create(message=_(u"Message successfully recovered."))
+        messages.info(request, _(u"Message successfully recovered."))
         if notification:
             notification.send([user], "messages_recovered", {'message': message,})
         return HttpResponseRedirect(success_url)


### PR DESCRIPTION
Django 1.4 removes support for the old messages API. This change
restores compatibility by using the modern django.contrib.messages API.
This has been tested and confirmed to work with 1.4 alpha 1.
