### PR TITLE
Include new README in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include AUTHORS
 include LICENSE
 include INSTALL
-include README
+include README.rst
 recursive-include django_messages/locale *.po *.mo
 recursive-include django_messages/templates *.html *.txt
 include docs/*


### PR DESCRIPTION
`setup.py` falls over trying to open it for `long_description` if it's not there.

Related to #5
