### PR TITLE
Set max_length for subject field in compose form to 120 chars.

### DIFF
--- a/django_messages/forms.py
+++ b/django_messages/forms.py
@@ -18,7 +18,7 @@ class ComposeForm(forms.Form):
     A simple default form for private messages.
     """
     recipient = CommaSeparatedUserField(label=_(u"Recipient"))
-    subject = forms.CharField(label=_(u"Subject"))
+    subject = forms.CharField(label=_(u"Subject"), max_length=120)
     body = forms.CharField(label=_(u"Body"),
         widget=forms.Textarea(attrs={'rows': '12', 'cols':'55'}))
     


### PR DESCRIPTION
This stops users from entering a message subject with
length greater than 120 chars in compose form and prevents
database integrity error during saving the message.

The value of max_length for subject field in compose form
is in accordance with max_length property of subject field
in Message model.
