### PR TITLE
option to disable notification

### DIFF
--- a/django_messages/admin.py
+++ b/django_messages/admin.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Group
 from django_messages.utils import get_user_model
 User = get_user_model()
 
-if "notification" in settings.INSTALLED_APPS:
+if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
     from notification import models as notification
 else:
     notification = None

--- a/django_messages/forms.py
+++ b/django_messages/forms.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 
-if "notification" in settings.INSTALLED_APPS:
+if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
     from notification import models as notification
 else:
     notification = None

--- a/django_messages/management.py
+++ b/django_messages/management.py
@@ -2,7 +2,7 @@ from django.db.models import get_models, signals
 from django.conf import settings
 from django.utils.translation import ugettext_noop as _
 
-if "notification" in settings.INSTALLED_APPS:
+if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
     from notification import models as notification
 
     def create_notice_types(app, created_models, verbosity, **kwargs):

--- a/django_messages/models.py
+++ b/django_messages/models.py
@@ -100,6 +100,6 @@ def inbox_count_for(user):
     return Message.objects.filter(recipient=user, read_at__isnull=True, recipient_deleted_at__isnull=True).count()
 
 # fallback for email notification if django-notification could not be found
-if "notification" not in settings.INSTALLED_APPS:
+if "notification" not in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
     from django_messages.utils import new_message_email
     signals.post_save.connect(new_message_email, sender=Message)

--- a/django_messages/views.py
+++ b/django_messages/views.py
@@ -14,7 +14,7 @@ from django_messages.utils import format_quote, get_user_model, get_username_fie
 
 User = get_user_model()
 
-if "notification" in settings.INSTALLED_APPS:
+if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
     from notification import models as notification
 else:
     notification = None


### PR DESCRIPTION
This makes it possible to disable notifications via DJANGO_MESSAGES_NOTIFY = False in the user settings. Otherwise it changes no functionality so it's backwards compatible.
