### PR TITLE
Better handling of deleted messages (Fixes #40)

### DIFF
--- a/django_messages/conf.py
+++ b/django_messages/conf.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+from appconf import AppConf
+
+class MessagesAppConf(AppConf):
+    DELETED_MAX_AGE = 30
+
+    class Meta:
+        prefix = 'MESSAGES'

--- a/django_messages/management.py
+++ b/django_messages/management.py
@@ -13,6 +13,7 @@ if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSA
         notification.create_notice_type("messages_deleted", _("Message Deleted"), _("you have deleted a message"), default=1)
         notification.create_notice_type("messages_permanently_deleted", _("Message Permanently Deleted"), _("you have permanently deleted a message"), default=0)
         notification.create_notice_type("messages_recovered", _("Message Recovered"), _("you have undeleted a message"), default=1)
+        notification.create_notice_type("empty_trash", _("Emptied Trash"), _("you have permanently deleted all messages in your trash bin"), default=0)
 
     signals.post_syncdb.connect(create_notice_types, sender=notification)
 else:

--- a/django_messages/management.py
+++ b/django_messages/management.py
@@ -11,6 +11,7 @@ if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSA
         notification.create_notice_type("messages_replied", _("Message Replied"), _("you have replied to a message"), default=1)
         notification.create_notice_type("messages_reply_received", _("Reply Received"), _("you have received a reply to a message"), default=2)
         notification.create_notice_type("messages_deleted", _("Message Deleted"), _("you have deleted a message"), default=1)
+        notification.create_notice_type("messages_permanently_deleted", _("Message Permanently Deleted"), _("you have permanently deleted a message"), default=0)
         notification.create_notice_type("messages_recovered", _("Message Recovered"), _("you have undeleted a message"), default=1)
 
     signals.post_syncdb.connect(create_notice_types, sender=notification)

--- a/django_messages/management/commands/delete_deleted_messages.py
+++ b/django_messages/management/commands/delete_deleted_messages.py
@@ -2,18 +2,19 @@ import datetime
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 from ...models import Message
+from django_messages.conf import settings
 
 
 class Command(BaseCommand):
     args = '<minimum age in days (e.g. 30)>'
     help = (
         'Deletes messages that have been marked as deleted by both the sender '
-        'and recipient. You must provide the minimum age in days.'
+        'and recipient. Minimum age in days is pulled from settings or given as an argument.'
     )
 
     def handle(self, *args, **options):
         if len(args) == 0:
-            raise CommandError('You must provide the minimum age in days.')
+            args = [settings.MESSAGES_DELETED_MAX_AGE]
         elif len(args) > 1:
             raise CommandError(
                 'This management command accepts only one argument.'

--- a/django_messages/models.py
+++ b/django_messages/models.py
@@ -1,9 +1,11 @@
+import datetime
 from django.conf import settings
 from django.db import models
 from django.db.models import signals
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+from django_messages.conf import settings
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
@@ -33,14 +35,15 @@ class MessageManager(models.Manager):
     def trash_for(self, user):
         """
         Returns all messages that were either received or sent by the given
-        user and are marked as deleted.
+        user and are marked as deleted since less than MESSAGES_DELETED_MAX_AGE days.
         """
+        the_date = timezone.now() - datetime.timedelta(days=settings.MESSAGES_DELETED_MAX_AGE)
         return self.filter(
             recipient=user,
-            recipient_deleted_at__isnull=False,
+            recipient_deleted_at__gt=the_date,
         ) | self.filter(
             sender=user,
-            sender_deleted_at__isnull=False,
+            sender_deleted_at__gt=the_date,
         )
 
 

--- a/django_messages/templates/django_messages/trash.html
+++ b/django_messages/templates/django_messages/trash.html
@@ -17,7 +17,7 @@
         {{ message.subject }}
         </td>
         <td>{{ message.sent_at|date:_("DATETIME_FORMAT") }}</td>
-        <td><a href="{% url 'messages_undelete' message.id %}">{% trans "undelete" %}</a></td>
+        <td><a href="{% url 'messages_undelete' message.id %}">{% trans "undelete" %}</a>, <a href="{% url 'messages_permanently_delete' message.id %}">{% trans "permanently delete" %}</a></td>
     </tr>
 {% endfor %}
     </tbody>
@@ -26,5 +26,5 @@
 <p>{% trans "No messages." %}</p>
 {% endif %}   
 <br />
-<p>{% trans "Deleted Messages are removed from the trash at unregular intervals, don't rely on this feature for long-time storage." %}</p>
+<p>{% blocktrans with deleted_max_age=max_age %} Deleted Messages are removed from the trash after {{deleted_max_age}} days, don't rely on this feature for long-time storage.{% endblocktrans %}</p>
 {% endblock %}

--- a/django_messages/templates/django_messages/trash.html
+++ b/django_messages/templates/django_messages/trash.html
@@ -5,6 +5,7 @@
 {% block content %} 
 <h1>{% trans "Deleted Messages" %}</h1>
 {% if message_list %} 
+<a href="{% url 'empty_trash' %}">{% trans "Empty trash" %}</a>
 <table class="messages">
     <thead>
         <tr><th>{% trans "Sender" %}</th><th>{% trans "Subject" %}</th><th>{% trans "Date" %}</th><th>{% trans "Action" %}</th></tr>

--- a/django_messages/urls.py
+++ b/django_messages/urls.py
@@ -15,4 +15,5 @@ urlpatterns = patterns('',
     url(r'^permanently_delete/(?P<message_id>[\d]+)/$', permanently_delete, name='messages_permanently_delete'),
     url(r'^undelete/(?P<message_id>[\d]+)/$', undelete, name='messages_undelete'),
     url(r'^trash/$', trash, name='messages_trash'),
+    url(r'^empty_trash/$', empty_trash, name='messages_empty_trash'),
 )

--- a/django_messages/urls.py
+++ b/django_messages/urls.py
@@ -12,6 +12,7 @@ urlpatterns = patterns('',
     url(r'^reply/(?P<message_id>[\d]+)/$', reply, name='messages_reply'),
     url(r'^view/(?P<message_id>[\d]+)/$', view, name='messages_detail'),
     url(r'^delete/(?P<message_id>[\d]+)/$', delete, name='messages_delete'),
+    url(r'^permanently_delete/(?P<message_id>[\d]+)/$', permanently_delete, name='messages_permanently_delete'),
     url(r'^undelete/(?P<message_id>[\d]+)/$', undelete, name='messages_undelete'),
     url(r'^trash/$', trash, name='messages_trash'),
 )

--- a/django_messages/views.py
+++ b/django_messages/views.py
@@ -46,7 +46,7 @@ def outbox(request, template_name='django_messages/outbox.html'):
 @login_required
 def trash(request, template_name='django_messages/trash.html'):
     """
-    Displays a list of deleted messages.
+    Displays a list of deleted messages which are less than MESSAGES_DELETED_MAX_AGE days old.
     Optional arguments:
         ``template_name``: name of the template to use
     Hint: A Cron-Job could periodicly clean up old messages, which are deleted

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
             'locale/*/LC_MESSAGES/*',
         ]
     },
+    install_requires=[
+        "django-appconf>=0.6",
+    ],
     classifiers=(
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
- Messages deleted more than `MESSAGES_DELETED_MAX_AGE` days ago do not appear in the trash.
- Users can mark a message as permanently deleted.

If both users permanently deleted a message or if message was deleted more than `MESSAGES_DELETED_MAX_AGE` days ago, then the message is removed from the database (on `permanently_delete()` call, on `empty_trash()` call or using `delete_deleted_messages.py`)

New dependency to handle `MESSAGES_DELETED_MAX_AGE` setting: [django-appconf](https://github.com/jezdez/django-appconf)

- I have not added extra tests.
- They could be mistakes in the use of the `notification` package.
- I have not updated the translations
