### PR TITLE
Add install_requires section with Django as a dependency to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ setup(
     author='Arne Brodowski',
     author_email='mail@arnebrodowski.de',
     url='https://github.com/arneb/django-messages',
+    install_requires=[
+        'Django'
+    ],
     packages=(
         'django_messages',
         'django_messages.templatetags',


### PR DESCRIPTION
I think it's a good idea to keep dependencies explicit in setup.py. Added benefit is that one can now set minimum Django version if need be.