### PR TITLE
setting to disable continual updates of read_at time

### DIFF
--- a/django_messages/views.py
+++ b/django_messages/views.py
@@ -208,7 +208,8 @@ def view(request, message_id, form_class=ComposeForm, quote_helper=format_quote,
     message = get_object_or_404(Message, id=message_id)
     if (message.sender != user) and (message.recipient != user):
         raise Http404
-    if message.read_at is None and message.recipient == user:
+    if message.read_at is None and message.recipient == user and \
+            (message.read_at is not None and getattr(settings, 'DJANGO_MESSAGES_UPDATE_READ_AT', True)):
         message.read_at = now
         message.save()
 


### PR DESCRIPTION
This prevents the continual updates of the read_at attribute. It's meant to not invalidate ORM cache frameworks like cacheops/johnny cache/etc. when a user looks at a message they have already read.