### PR TITLE
bugfix: issue 65. "management.py", line 1, in <module> from django.db…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ speedy
 Sergio Morstabilini
 paluh
 Jeong YunWon
+Jay S. Liew

--- a/django_messages/management.py
+++ b/django_messages/management.py
@@ -1,4 +1,4 @@
-from django.db.models import get_models, signals
+from django.db.models import signals
 from django.conf import settings
 from django.utils.translation import ugettext_noop as _
 


### PR DESCRIPTION
….models import get_models, signals ImportError: cannot import name get_models