### PR TITLE
Updates test suite and README for Django 1.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Versions
 --------
 
 +-------+-------------------------------------------------------------------+
-| 0.6.x | compatible with Django 1.7, 1.8, 1.9 and with Python 3            |
+| 0.6.x | compatible with Django 1.7, 1.8, 1.9, 1.10 and with Python 3      |
 +-------+-------------------------------------------------------------------+
 | 0.5.x | compatible with Django 1.4, 1.5, 1.6 and 1.7; if you are          |
 |       | upgrading from 0.4.x to trunk please read the UPGRADING docs.     |

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -32,3 +32,19 @@ DATABASES = {
         'NAME': os.path.join(os.path.dirname(__file__), 'database.db'),
     }
 }
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py2.7-d1.5, py2.7-d1.6, py2.7-d1.7, py2.7-d1.8, py2.7-d1.9,
+    py2.7-d1.5, py2.7-d1.6, py2.7-d1.7, py2.7-d1.8, py2.7-d1.9, py2.7-d1.10
     py3.3-d1.5, py3.3-d1.6, py3.3-d1.7,
     py3.4-d1.7,
-    py3.5-d1.8, py3.5-d1.9
+    py3.5-d1.8, py3.5-d1.9, py3.5-d1.10
 
 [testenv]
 commands = {envpython} tests/manage.py test django_messages --settings=settings
@@ -31,6 +31,10 @@ deps = django>=1.8,<1.9
 [testenv:py2.7-d1.9]
 basepython = python2.7
 deps = django>=1.9,<1.9.99
+
+[testenv:py2.7-d1.10]
+basepython = python2.7
+deps = django>=1.10,<1.10.99
 
 # Python 3.3
 
@@ -62,3 +66,7 @@ deps = django>=1.8,<1.9
 [testenv:py3.5-d1.9]
 basepython = python3.5
 deps = django>=1.9,<1.9.99
+
+[testenv:py3.5-d1.10]
+basepython = python3.5
+deps = django>=1.10,<10.99


### PR DESCRIPTION
As a companion to pull request #79 , this PR updates the README to list Django 1.10 in the supported versions for 0.6, and updates the test suite configuration to test against Django 1.10 on Python 2.7 and 3.5.

Since the `TEMPLATES` setting is [now empty by default](https://docs.djangoproject.com/en/1.10/topics/templates/#configuration), it is now explicitly specified in the test suite settings.