### PR TITLE
import 'pinax.notifications' instead of 'notification' (fixes issue #90)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,9 @@ Dependencies
 ------------
 
 Django-messages has no external dependencies except for django. However, if
-django-notification and/or django-mailer are found, it will make use of them.
-Note: as of r65 django-messages will only use django-notification if
-'notification' is also added to the INSTALLED_APPS setting. This has been
+pinax-notifications and/or django-mailer are found, it will make use of them.
+Note: as of r65 django-messages will only use pinax-notifications if
+'pinax.notifications' is also added to the INSTALLED_APPS setting. This has been
 done to make situations possible where notification is on pythonpath but
 should not be used, or where notification is another python package, such as
 django-notification which has the same name.

--- a/django_messages/admin.py
+++ b/django_messages/admin.py
@@ -7,8 +7,8 @@ from django.contrib.auth.models import Group
 from django_messages.utils import get_user_model
 User = get_user_model()
 
-if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
-    from notification import models as notification
+if "pinax.notifications" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
+    from pinax.notifications import models as notification
 else:
     notification = None
 

--- a/django_messages/forms.py
+++ b/django_messages/forms.py
@@ -3,8 +3,8 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 
-if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
-    from notification import models as notification
+if "pinax.notifications" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
+    from pinax.notifications import models as notification
 else:
     notification = None
 

--- a/django_messages/management.py
+++ b/django_messages/management.py
@@ -2,8 +2,8 @@ from django.db.models import signals
 from django.conf import settings
 from django.utils.translation import ugettext_noop as _
 
-if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
-    from notification import models as notification
+if "pinax.notifications" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
+    from pinax.notifications import models as notification
 
     def create_notice_types(app, created_models, verbosity, **kwargs):
         notification.create_notice_type("messages_received", _("Message Received"), _("you have received a message"), default=2)

--- a/django_messages/models.py
+++ b/django_messages/models.py
@@ -100,6 +100,6 @@ def inbox_count_for(user):
     return Message.objects.filter(recipient=user, read_at__isnull=True, recipient_deleted_at__isnull=True).count()
 
 # fallback for email notification if django-notification could not be found
-if "notification" not in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
+if "pinax.notifications" not in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
     from django_messages.utils import new_message_email
     signals.post_save.connect(new_message_email, sender=Message)

--- a/django_messages/views.py
+++ b/django_messages/views.py
@@ -14,8 +14,8 @@ from django_messages.utils import format_quote, get_user_model, get_username_fie
 
 User = get_user_model()
 
-if "notification" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
-    from notification import models as notification
+if "pinax.notifications" in settings.INSTALLED_APPS and getattr(settings, 'DJANGO_MESSAGES_NOTIFY', True):
+    from pinax.notifications import models as notification
 else:
     notification = None
 

--- a/docs/customizing.txt
+++ b/docs/customizing.txt
@@ -33,7 +33,7 @@ Django-messages uses the following templates:
 * :file:`django_messages/view.html` - This template renders a single message 
   with all details.
 
-Additionally django-message provides a set of template for django-notification.
+Additionally django-message provides a set of template for pinax-notifications.
 These template can be found in :file:`django_messages/templates/notification/` 
 and can also be overwritten in one of your project's ``TEMPLATE_DIRS``.
 

--- a/docs/install.txt
+++ b/docs/install.txt
@@ -74,7 +74,7 @@ Django-messages has some features which may use an external app if it is
 present in the current Django project. Please note, that these apps have to
 be listed in ``INSTALLED_APPS`` to be used by django-messages.
 
-* If you use `django-notification`_ django-messages will use it for sending
+* If you use `pinax-notifications`_ django-messages will use it for sending
   notifications to users about new messages instead of using the built-in
   mechanism
   
@@ -86,5 +86,5 @@ on Python 2.5 sometimes code might slip in which breaks Python 2.4 compatibility
 This can be considered a bug and you can help us by reporting the incompytibility.
 
 
-.. _`django-notification`: http://code.google.com/p/django-notification/
+.. _`pinax-notifications`: https://github.com/pinax/pinax-notifications
 .. _`django-mailer`: http://code.google.com/p/django-mailer/

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -91,7 +91,7 @@ Settings Options
 ----------------
 
 If you do want to disable django-messages from sending either a
-'django-notification' notice or an email (fallback if 'django-notification
+'pinax-notifications' notice or an email (fallback if 'pinax-notifications
 not installed' then set the following in your django settings::
 
     DJANGO_MESSAGES_NOTIFY = False


### PR DESCRIPTION
The project `django-notification` changed its name and location to `pinax-notifications`. Instead of `notification`, `pinax.notifications` must be imported to use the current version of this module.