### PR TITLE
Django 1.11 added to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py2.7-d1.7, py2.7-d1.8, py2.7-d1.9, py2.7-d1.10,
-    py3.5-d1.8, py3.5-d1.9, py3.5-d1.10
+    py2.7-d1.7, py2.7-d1.8, py2.7-d1.9, py2.7-d1.10, py2.7-d1.11,
+    py3.5-d1.8, py3.5-d1.9, py3.5-d1.10, py3.5-d1.11
 
 [testenv]
 commands = {envpython} tests/manage.py test django_messages --settings=settings
@@ -25,6 +25,10 @@ deps = django>=1.9,<1.9.99
 basepython = python2.7
 deps = django>=1.10,<1.10.99
 
+[testenv:py2.7-d1.11]
+basepython = python2.7
+deps = django>=1.11,<1.11.99
+
 # Python 3.5
 
 [testenv:py3.5-d1.8]
@@ -38,3 +42,7 @@ deps = django>=1.9,<1.9.99
 [testenv:py3.5-d1.10]
 basepython = python3.5
 deps = django>=1.10,<1.10.99
+
+[testenv:py3.5-d1.11]
+basepython = python3.5
+deps = django>=1.11,<1.11.99


### PR DESCRIPTION
I haven't validated that the project works with Django 1.11 but the tests do pass.