### PR TITLE
Optional pagination

### DIFF
--- a/django_messages/templates/django_messages/_pagination.html
+++ b/django_messages/templates/django_messages/_pagination.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+<div class="pagination">
+    <span class="step-links">
+        {% if message_list.has_previous %}
+        <a href="?page=1">&laquo; {% trans "first" %}</a>
+        <a href="?page={{ message_list.previous_page_number }}">{% trans "previous" %}</a>
+        {% endif %}
+        <span class="current">
+            {% with page_num=message_list.number total=message_list.paginator.num_pages %}
+            {% blocktrans %}Page {{ page_num }} of {{ total }}.{% endblocktrans %}
+            {% endwith %}
+        </span>
+        {% if message_list.has_next %}
+        <a href="?page={{ message_list.next_page_number }}">{% trans "next" %}</a>
+        <a href="?page={{ message_list.paginator.num_pages }}">{% trans "last" %} &raquo;</a>
+        {% endif %}
+    </span>
+</div>

--- a/django_messages/templates/django_messages/inbox.html
+++ b/django_messages/templates/django_messages/inbox.html
@@ -24,6 +24,10 @@
 {% endfor %}
     </tbody>
 </table>
+{% if message_list.has_other_pages %}
+<br/>
+{% include "django_messages/_pagination.html" %}
+{% endif %}
 {% else %}
 <p>{% trans "No messages." %}</p>
 {% endif %}

--- a/django_messages/templates/django_messages/outbox.html
+++ b/django_messages/templates/django_messages/outbox.html
@@ -21,6 +21,10 @@
 {% endfor %}
     </tbody>
 </table>
+{% if message_list.has_other_pages %}
+<br/>
+{% include "django_messages/_pagination.html" %}
+{% endif %}
 {% else %}
 <p>{% trans "No messages." %}</p>
 {% endif %}

--- a/django_messages/templates/django_messages/trash.html
+++ b/django_messages/templates/django_messages/trash.html
@@ -21,6 +21,10 @@
 {% endfor %}
     </tbody>
 </table>
+{% if message_list.has_other_pages %}
+<br/>
+{% include "django_messages/_pagination.html" %}
+{% endif %}
 {% else %}
 <p>{% trans "No messages." %}</p>
 {% endif %}

--- a/django_messages/utils.py
+++ b/django_messages/utils.py
@@ -2,7 +2,6 @@ import re
 import django
 from django.utils.text import wrap
 from django.utils.translation import ugettext, ugettext_lazy as _
-from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 from django.conf import settings
 
@@ -73,6 +72,7 @@ def new_message_email(sender, instance, signal,
 
     if 'created' in kwargs and kwargs['created']:
         try:
+            from django.contrib.sites.models import Site
             current_domain = Site.objects.get_current().domain
             subject = subject_prefix % {'subject': instance.subject}
             message = render_to_string(template_name, {

--- a/django_messages/utils.py
+++ b/django_messages/utils.py
@@ -4,6 +4,7 @@ from django.utils.text import wrap
 from django.utils.translation import ugettext, ugettext_lazy as _
 from django.template.loader import render_to_string
 from django.conf import settings
+from django.core.paginator import Paginator
 
 # favour django-mailer but fall back to django.core.mail
 
@@ -11,6 +12,10 @@ if "mailer" in settings.INSTALLED_APPS:
     from mailer import send_mail
 else:
     from django.core.mail import send_mail
+
+
+PAGE_LENGTH = getattr(settings, 'DJANGO_MESSAGES_PAGE_LENGTH', -1)
+
 
 def format_quote(sender, body):
     """
@@ -101,3 +106,11 @@ def get_username_field():
         return get_user_model().USERNAME_FIELD
     else:
         return 'username'
+
+
+def paginate_queryset(request, qs):
+    if PAGE_LENGTH == -1:
+        # Disable pagination
+        return qs
+    paginator = Paginator(qs, PAGE_LENGTH)
+    return paginator.get_page(request.GET.get('page', 1))

--- a/django_messages/utils.py
+++ b/django_messages/utils.py
@@ -4,7 +4,7 @@ from django.utils.text import wrap
 from django.utils.translation import ugettext, ugettext_lazy as _
 from django.template.loader import render_to_string
 from django.conf import settings
-from django.core.paginator import Paginator
+from django.core.paginator import Paginator, InvalidPage
 
 # favour django-mailer but fall back to django.core.mail
 
@@ -113,4 +113,8 @@ def paginate_queryset(request, qs):
         # Disable pagination
         return qs
     paginator = Paginator(qs, PAGE_LENGTH)
-    return paginator.get_page(request.GET.get('page', 1))
+    page_num = request.GET.get('page', 1)
+    try:
+        return paginator.page(page_num)
+    except InvalidPage:
+        return paginator.page(1)

--- a/django_messages/views.py
+++ b/django_messages/views.py
@@ -13,7 +13,8 @@ from django.conf import settings
 
 from django_messages.models import Message
 from django_messages.forms import ComposeForm
-from django_messages.utils import format_quote, get_user_model, get_username_field
+from django_messages.utils import format_quote, get_user_model, get_username_field, paginate_queryset
+
 
 User = get_user_model()
 
@@ -29,7 +30,10 @@ def inbox(request, template_name='django_messages/inbox.html'):
     Optional Arguments:
         ``template_name``: name of the template to use.
     """
-    message_list = Message.objects.inbox_for(request.user)
+    message_list = paginate_queryset(
+        request,
+        Message.objects.inbox_for(request.user)
+    )
     return render(request, template_name, {
         'message_list': message_list,
     })
@@ -41,7 +45,10 @@ def outbox(request, template_name='django_messages/outbox.html'):
     Optional arguments:
         ``template_name``: name of the template to use.
     """
-    message_list = Message.objects.outbox_for(request.user)
+    message_list = paginate_queryset(
+        request,
+        Message.objects.outbox_for(request.user)
+    )
     return render(request, template_name, {
         'message_list': message_list,
     })
@@ -55,7 +62,10 @@ def trash(request, template_name='django_messages/trash.html'):
     Hint: A Cron-Job could periodicly clean up old messages, which are deleted
     by sender and recipient.
     """
-    message_list = Message.objects.trash_for(request.user)
+    message_list = paginate_queryset(
+        request,
+        Message.objects.trash_for(request.user)
+    )
     return render(request, template_name, {
         'message_list': message_list,
     })

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -90,6 +90,14 @@ And now every Template Context will contain a variable named
 Settings Options
 ----------------
 
+By default, message list is not paginated, you can enable pagination by
+adding the following to your ``settings.py``::
+
+    DJANGO_MESSAGES_PAGE_LENGTH = 50  # or whatever number you want
+
+To disable pagination remove the setting variable or set it to -1.
+
+
 If you do want to disable django-messages from sending either a
 'pinax-notifications' notice or an email (fallback if 'pinax-notifications
 not installed' then set the following in your django settings::


### PR DESCRIPTION
By default, message list is not paginated, but now one can enable pagination
by setting ``DJANGO_MESSAGES_PAGE_LENGTH`` to a positive integer.

Pagination is disabled if this setting variable is not defined or set to -1.